### PR TITLE
Fix user resources

### DIFF
--- a/src/Authress.SDK/Api/UserPermissionsApi.cs
+++ b/src/Authress.SDK/Api/UserPermissionsApi.cs
@@ -80,7 +80,7 @@ namespace Authress.SDK
 
             var path = $"/v1/users/{System.Web.HttpUtility.UrlEncode(userId)}/resources";
             if (!string.IsNullOrEmpty(resourceCollectionUri)) {
-                path = $"{path}?{System.Web.HttpUtility.UrlEncode(resourceCollectionUri)}";
+                path = $"{path}?resourceUri={System.Web.HttpUtility.UrlEncode(resourceCollectionUri)}";
             }
             var client = await authressHttpClientProvider.GetHttpClientAsync();
             using (var response = await client.GetAsync(path))


### PR DESCRIPTION
GetUserResources seems to be missing a query param and using that method yields:

`Request .query should NOT have additional properties.`

returned by the API.

I think this is the missing part of the API call.