### PR TITLE
Allow path component in base URL

### DIFF
--- a/src/Authress.SDK/Authress.SDK.csproj
+++ b/src/Authress.SDK/Authress.SDK.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Authress SDK</Description>
     <AssemblyTitle>Authress SDK</AssemblyTitle>
@@ -31,4 +31,9 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.1"/>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7"/>
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>Authress.SDK.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+</ItemGroup>
 </Project>

--- a/tests/Authress.SDK/RewriteBaseUrlHandlerTests.cs
+++ b/tests/Authress.SDK/RewriteBaseUrlHandlerTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Authress.SDK.Client;
+using FluentAssertions;
+using Xunit;
+
+namespace Authress.SDK.UnitTests
+{
+    public class RewriteBaseUrlHandlerTests
+    {
+        [Fact]
+        public async Task AppendsRequestPath() =>
+            (await GetRewrittenUrl("https://example.com", "/request-path"))
+            .Should().Be("https://example.com/request-path");
+
+        [Theory]
+        [InlineData("/relative-path")]
+        [InlineData("relative-path")]
+        public async Task PreservesBaseUrlPath(string relativePath) =>
+            (await GetRewrittenUrl("https://example.com/path/", relativePath))
+            .Should().Be("https://example.com/path/relative-path");
+
+        [Fact]
+        public async Task PassesQuery() =>
+            (await GetRewrittenUrl("https://example.com", "/path?paramName=paramValue"))
+            .Should().Be("https://example.com/path?paramName=paramValue");
+
+        [Fact]
+        public async Task PassesFragment() =>
+            (await GetRewrittenUrl("https://example.com", "/path#fragment"))
+            .Should().Be("https://example.com/path#fragment");
+
+        private static async Task<string> GetRewrittenUrl(string baseUrl, string relativePath)
+        {
+            var innerHandler = new TestHandler();
+            var handler = new RewriteBaseUrlHandler(innerHandler, baseUrl);
+            var client = new HttpClient(handler) { BaseAddress = new Uri(baseUrl) };
+
+            await client.GetAsync(relativePath);
+            return innerHandler.RequestUri;
+        }
+
+        private class TestHandler : DelegatingHandler
+        {
+            public string RequestUri { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                RequestUri = request.RequestUri.ToString();
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change allows using Authress through a proxy with a path component in its URL, e.g. https://example.com/authressProxyPath/

As described in https://tools.ietf.org/html/rfc3986#section-5.2.3 merging a base URI with a relative URI containing leading slash removes the base URI's path component.